### PR TITLE
support the upstream kernel versions (BCM2835/6) as well

### DIFF
--- a/raspi-gpio.c
+++ b/raspi-gpio.c
@@ -196,7 +196,11 @@ int get_cpu_type(void)
 
   if (strstr(line, "BCM2709") != NULL)
     return PROC_TYPE_BCM2709;
+  if (strstr(line, "BCM2836") != NULL)
+    return PROC_TYPE_BCM2709;
   else if (strstr(line, "BCM2708") != NULL)
+    return PROC_TYPE_BCM2708;
+  else if (strstr(line, "BCM2835") != NULL)
     return PROC_TYPE_BCM2708;
   else
   {


### PR DESCRIPTION
Signed-off-by: Martin Sperl kernel@martin.sperl.org
